### PR TITLE
multiple bugfixes, cat62 update to v1.18, compound item bugfix

### DIFF
--- a/asterix.py
+++ b/asterix.py
@@ -358,8 +358,7 @@ class AsterixDecoder():
         for itemid in itemids:
             for dataitem in self.dataitems:
                 if dataitem.getAttribute('id') == itemid:
-                    dataitemformat = dataitem.getElementsByTagName('DataItemFormat')[
-                        0]
+                    dataitemformat = dataitem.getElementsByTagName('DataItemFormat')[0]
                     for cn in dataitemformat.childNodes:
                         r = None
                         if cn.nodeName == 'Fixed':
@@ -385,8 +384,7 @@ class AsterixDecoder():
         data = int.from_bytes(_bytes, byteorder='big', signed=False)
 
         for bits in bitslist:
-            bit_name = bits.getElementsByTagName('BitsShortName')[
-                0].firstChild.nodeValue
+            bit_name = bits.getElementsByTagName('BitsShortName')[0].firstChild.nodeValue
 
             bit = bits.getAttribute('bit')
             if bit != '':
@@ -457,7 +455,7 @@ class AsterixDecoder():
         mask = 1 << (8 * indicator_octetslen - 1)
         indicator = 1
         for i in range(0, 8 * indicator_octetslen):
-            if i % 8 != 7:  # i is FX
+            if i % 8 == 7:  # i is FX
                 continue
 
             if indicator_octets & (mask >> i) > 0:

--- a/asterix.py
+++ b/asterix.py
@@ -472,7 +472,7 @@ class AsterixDecoder():
             if cn.nodeName not in ['Fixed', 'Repetitive', 'Variable', 'Compound']:
                 continue
 
-            if index not in indicator:
+            if index not in indicators:
                 index += 1
                 continue
 

--- a/config/asterix_cat062_1_18.xml
+++ b/config/asterix_cat062_1_18.xml
@@ -24,7 +24,7 @@
                                                      I062/380 STAT Field updated with values 6 and 7 to align with Cat. 020
 -->
 
-<Category id="62" name="SDPS Track Messages" ver="1.17">
+<Category id="62" name="SDPS Track Messages" ver="1.18">
 	
 	<DataItem id="010" rule="mandatory" >
 		<DataItemName>Data Source Identifier</DataItemName>	

--- a/config/asterix_cat062_1_18.xml
+++ b/config/asterix_cat062_1_18.xml
@@ -1,0 +1,3039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE Category SYSTEM "asterix.dtd">
+
+<!--  
+
+	Asterix Category 62 v1.16 definition 
+	
+	Author:   dmarkus
+	Created:  5.11.2012.
+	Modified: 10.5.2013.
+	Modified: 3.11.2013. (dmarkus) : I062/SP defined as Explicit(content unknown)
+	Modified: 5.03.2014. (dmarkus) : I062/390 corrected
+  Modified: 11.03.2014. (B.Bertrand) : Fix encoding of several DataItems
+                                       Add BitsValue to DataItem I062/300
+                                       Add definition of repetitive field of DataItem I062/380
+                                       Fix length of B1B field (DataItem I062/380)
+                                       Add missing fields to DataItem I062/390
+    Modified:  28.04.2014. (dsalantic) Special characters removed from BitsShortName, some BitsShortName renamed, tabs aligned
+    Modified:  05.05.2014. (dsalantic) Item 110 format fixed
+    Modified:  04.07.2020. (fjonckers) cat062 v1.17: V & G bits added to I062/060 (correct name)
+-->
+
+<Category id="62" name="SDPS Track Messages" ver="1.17">
+	
+	<DataItem id="010" rule="mandatory" >
+		<DataItemName>Data Source Identifier</DataItemName>	
+		<DataItemDefinition>Identification of the system sending the data</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="2">
+				<Bits from="16" to="9">
+					<BitsShortName>SAC</BitsShortName>
+					<BitsName>System Area Code</BitsName>
+				</Bits>
+				<Bits from="8" to="1">
+					<BitsShortName>SIC</BitsShortName>
+					<BitsName>System Identification Code</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>The up-to-date list of SACs is published on the EUROCONTROL Web Site (http://www.eurocontrol.int/asterix).</DataItemNote>
+	</DataItem>
+	
+	<DataItem id="015" rule="optional">
+		<DataItemName>Service Identification</DataItemName>
+		<DataItemDefinition>Identification of the service provided to one or more users.</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="1">
+				<Bits from="8" to="1">
+					<BitsShortName>SID</BitsShortName>
+					<BitsName>Service Identification</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>the service identification is allocated by the system</DataItemNote>
+	</DataItem>
+	
+	<DataItem id="040" rule="mandatory">
+		<DataItemName>Track Number</DataItemName>
+		<DataItemDefinition>Identification of a track</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="2">
+				<Bits from="16" to="1">
+					<BitsShortName>TrkN</BitsShortName>
+					<BitsName>Track number</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>This Item shall be present in every ASTERIX record</DataItemNote>
+	</DataItem>
+	
+	<DataItem id="060" rule="optional">
+		<DataItemName>Track Mode 3/A Code</DataItemName>
+		<DataItemDefinition>Mode-3/A code converted into octal representation.</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="2">
+				<Bits bit="16">
+					<BitsShortName>V</BitsShortName>
+					<BitsName>Mode 3/A validated</BitsName>
+					<BitsValue val="0">Default</BitsValue>
+					<BitsValue val="1">Code not validated</BitsValue>
+				</Bits>
+				<Bits bit="15">
+					<BitsShortName>G</BitsShortName>
+					<BitsName>Mode 3/A garbled</BitsName>
+					<BitsValue val="0">Default</BitsValue>
+					<BitsValue val="1">Garbled Code</BitsValue>
+				</Bits>
+				<Bits bit="14">
+					<BitsShortName>CH</BitsShortName>
+					<BitsName>Change in Mode 3/A</BitsName>
+					<BitsValue val="0">No Change</BitsValue>
+					<BitsValue val="1">Mode 3/A has changed</BitsValue>
+				</Bits>
+				<Bits bit="13">
+					<BitsShortName>spare</BitsShortName>
+					<BitsName>Spare bits set to 0</BitsName>
+					<BitsConst>0</BitsConst>
+				</Bits>
+				<Bits from="12" to="1" encode="octal">
+					<BitsShortName>Mode3A</BitsShortName>
+					<BitsName>Mode-3/A reply in octal representation</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+	</DataItem>	
+				
+	<DataItem id="070" rule="mandatory" >
+		<DataItemName>Time Of Track Information</DataItemName>
+		<DataItemDefinition>Absolute time stamping of the information provided in the track message, in the form of elapsed time since last midnight, expressed as UTC.</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="3">
+				<Bits from="24" to="1">
+					<BitsShortName>ToT</BitsShortName>
+					<BitsName>Time Of Track Information</BitsName>
+					<BitsUnit scale="0.0078125">s</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>1. This is the time of the track state vector. 2. The time is reset to zero at every midnight.</DataItemNote>
+	</DataItem>		
+				
+	<DataItem id="080" rule="mandatory">
+		<DataItemName>Track Status</DataItemName>
+		<DataItemDefinition>Status of a track.</DataItemDefinition>
+		<DataItemFormat>
+			<Variable>
+				<Fixed length="1">
+					<Bits bit="8">
+						<BitsShortName>MON</BitsShortName>
+						<BitsValue val="0">Multisensor track</BitsValue>
+						<BitsValue val="1">Monosensor track</BitsValue>
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>SPI</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">SPI present in the last report received from a sensor capable of decoding this data</BitsValue>
+					</Bits>
+					<Bits bit="6">
+						<BitsShortName>MRH</BitsShortName>
+						<BitsName>Most Reliable Height</BitsName>
+						<BitsValue val="0">Barometric altitude (Mode C) more reliable</BitsValue>
+						<BitsValue val="1">Geometric altitude more reliable</BitsValue>
+					</Bits>
+					<Bits from="5" to="3">
+						<BitsShortName>SRC</BitsShortName>
+						<BitsName>Source of calculated track altitude for I062/130</BitsName>
+						<BitsValue val="0">no source</BitsValue>
+						<BitsValue val="1">GNSS</BitsValue>
+						<BitsValue val="2">3D radar</BitsValue>
+						<BitsValue val="3">triangulation</BitsValue>
+						<BitsValue val="4">height from coverage</BitsValue>
+						<BitsValue val="5">speed look-up table</BitsValue>
+						<BitsValue val="6">default height</BitsValue>
+						<BitsValue val="7">multilateration</BitsValue>
+					</Bits>
+					<Bits bit="2">
+						<BitsShortName>CNF</BitsShortName>
+						<BitsValue val="0">Confirmed track</BitsValue>
+						<BitsValue val="1">Tentative track</BitsValue>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">end of data item</BitsValue>
+						<BitsValue val="1">extension into first extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits bit="8">
+						<BitsShortName>SIM</BitsShortName>
+						<BitsValue val="0">Actual track</BitsValue>
+						<BitsValue val="1">Simulated track</BitsValue>
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>TSE</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">last message transmitted to the user for the track</BitsValue>
+					</Bits>
+					<Bits bit="6">
+						<BitsShortName>TSB</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">first message transmitted to the user for the track</BitsValue>
+					</Bits>
+					<Bits bit="5">
+						<BitsShortName>FPC</BitsShortName>
+						<BitsValue val="0">Not flight-plan correlated</BitsValue>
+						<BitsValue val="1">Flight plan correlated</BitsValue>
+					</Bits>
+					<Bits bit="4">
+						<BitsShortName>AFF</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">ADS-B data inconsistent with other surveillance information</BitsValue>
+					</Bits>
+					<Bits bit="3">
+						<BitsShortName>STP</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">Slave Track Promotion</BitsValue>
+					</Bits>
+					<Bits bit="2">
+						<BitsShortName>KOS</BitsShortName>
+						<BitsValue val="0">Complementary service used</BitsValue>
+						<BitsValue val="1">Background service used</BitsValue>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">End of data item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits bit="8">
+						<BitsShortName>AMA</BitsShortName>
+						<BitsValue val="0">track not resulting from amalgamation process</BitsValue>
+						<BitsValue val="1">track resulting from amalgamation process</BitsValue>
+					</Bits>
+					<Bits from="7" to="6">
+						<BitsShortName>MD4</BitsShortName>
+						<BitsValue val="0">No Mode 4 interrogation</BitsValue>
+						<BitsValue val="1">Friendly target</BitsValue>
+						<BitsValue val="2">Unknown target</BitsValue>
+						<BitsValue val="3">No reply</BitsValue>
+					</Bits> 
+					<Bits bit="5">
+						<BitsShortName>ME</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">Military Emergency present in the last report received from a sensor capable of decoding this data</BitsValue>
+					</Bits>
+					<Bits bit="4">
+						<BitsShortName>MI</BitsShortName>
+						<BitsValue val="0">default value</BitsValue>
+						<BitsValue val="1">Military Identification present in the last report received from a sensor capable of decoding this data</BitsValue>
+					</Bits>
+					<Bits from="3" to="2">
+						<BitsShortName>MD5</BitsShortName>
+						<BitsValue val="0">No Mode 5 interrogation</BitsValue>
+						<BitsValue val="1">Friendly target</BitsValue>
+						<BitsValue val="2">Unknown target</BitsValue>
+						<BitsValue val="3">No reply</BitsValue>
+					</Bits> 
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">End of data item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits bit="8">
+						<BitsShortName>CST</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Age of the last received track update is higher than system dependent threshold (coasting)</BitsValue>
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>PSR</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Age of the last received PSR track update is higher than system dependent threshold</BitsValue>
+					</Bits>
+					<Bits bit="6">
+						<BitsShortName>SSR</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Age of the last received SSR track update is higher than system dependent threshold</BitsValue>
+					</Bits>
+					<Bits bit="5">
+						<BitsShortName>MDS</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Age of the last received Mode S track update is higher than system dependent threshold</BitsValue>
+					</Bits>
+					<Bits bit="4">
+						<BitsShortName>ADS</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Age of the last received ADS-B track update is higher than system dependent threshold</BitsValue>
+					</Bits>
+					<Bits bit="3">
+						<BitsShortName>SUC</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Special Used Code (Mode A codes to be defined in the system to mark a track with special interest)</BitsValue>
+					</Bits>
+					<Bits bit="2">
+						<BitsShortName>AAC</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Assigned Mode A Code Conflict (same discrete Mode A Code assigned to another track)</BitsValue>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">End of data item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="7">
+						<BitsShortName>SDS</BitsShortName>
+						<BitsValue val="0">Combined</BitsValue>
+						<BitsValue val="1">Co-operative only</BitsValue>
+						<BitsValue val="2">Non-Cooperative only</BitsValue>
+						<BitsValue val="3">Not defined</BitsValue>
+					</Bits>
+					<Bits from="6" to="4">
+						<BitsShortName>EMS</BitsShortName>
+						<BitsValue val="0">No emergency</BitsValue>
+						<BitsValue val="1">General emergency</BitsValue>
+						<BitsValue val="2">Lifeguard / medical</BitsValue>
+						<BitsValue val="3">Minimum fuel</BitsValue>
+						<BitsValue val="4">No communications</BitsValue>
+						<BitsValue val="5">Unlawful interference</BitsValue>
+						<BitsValue val="6">Downed Aircraft</BitsValue>
+						<BitsValue val="7">Undefined</BitsValue>
+					</Bits>
+					<Bits bit="3">
+						<BitsShortName>PFT</BitsShortName>
+						<BitsValue val="0">No indication</BitsValue>
+						<BitsValue val="1">Potential False Track Indication</BitsValue>
+					</Bits>
+					<Bits bit="2">
+						<BitsShortName>FPLT</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Track created / updated with FPL data</BitsValue>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">End of data item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits bit="8">
+						<BitsShortName>DUPT</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Duplicate Mode 3/A Code</BitsValue>
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>DUPF</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Duplicate Flight Plan</BitsValue>
+					</Bits>
+					<Bits bit="6">
+						<BitsShortName>DUPM</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Duplicate Flight Plan due to manual correlation</BitsValue>
+					</Bits>
+					<Bits from="5" to="2">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bits set to 0</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsValue val="0">End of data item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+
+
+			</Variable>
+		</DataItemFormat>
+		<DataItemNote>1. Track type and coasting can also be derived from I062/290 System Track Update Ages 2. If the system supports the technology, default value (0) means that the technology was used to produce the report 3. If the system does not support the technology, default value is meaningless.</DataItemNote>
+	</DataItem>
+	
+	<DataItem id="100" rule="optional">
+		<DataItemName>Calculated Track Position. (Cartesian)</DataItemName>
+		<DataItemDefinition>Calculated position in Cartesian co-ordinates with a resolution of 0.5m, in two’s complement form.</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="6">
+				<Bits from="48" to="25" encode="signed">
+					<BitsShortName>X</BitsShortName>
+					<BitsName>X</BitsName>
+					<BitsUnit scale="0.5">m</BitsUnit>
+				</Bits>
+				<Bits from="24" to="1" encode="signed">
+					<BitsShortName>Y</BitsShortName>
+					<BitsName>Y</BitsName>
+					<BitsUnit scale="0.5">m</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+	</DataItem>
+		
+	<DataItem id="105" rule="optional">
+		<DataItemName>Calculated Position In WGS-84 Co-ordinates</DataItemName>
+		<DataItemDefinition>Calculated Position in WGS-84 Co-ordinates with a resolution of 180/225. degrees</DataItemDefinition>
+		<DataItemFormat>
+			<Fixed length="8">
+				<Bits from="64" to="33" encode="signed">
+					<BitsShortName>Lat</BitsShortName>
+					<BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; latitude &lt; 90 deg.</BitsName>
+					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
+				</Bits>
+				<Bits from="32" to="1" encode="signed">
+					<BitsShortName>Lon</BitsShortName>
+					<BitsName>Longitude in WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>The LSB provides a resolution at least better than 0.6m</DataItemNote>
+	</DataItem>
+	
+	<DataItem id="110" rule="optional">
+		<DataItemName>Mode 5 Data reports and Extended Mode 1 Code</DataItemName>
+		<DataItemDefinition>Mode 5 Data reports and Extended Mode 1 Code</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of one octet, followed by the indicated subfields.">
+			<Compound>
+                <Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>SUM</BitsShortName>
+                            <BitsName>Mode 5 Summary</BitsName>
+                            <BitsPresence>1</BitsPresence>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>PMN</BitsShortName>
+                            <BitsName>Mode 5 PIN/ National Origin/Mission Code</BitsName>
+                            <BitsPresence>2</BitsPresence>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>POS</BitsShortName>
+                            <BitsName>Mode 5 Reported Position</BitsName>
+                            <BitsPresence>3</BitsPresence>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>GA</BitsShortName>
+                            <BitsName>Mode 5 GNSS-derived Altitude</BitsName>
+                            <BitsPresence>4</BitsPresence>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>EM1</BitsShortName>
+                            <BitsName>Extended Mode 1 Code in Octal Representation</BitsName>
+                            <BitsPresence>5</BitsPresence>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>TOS</BitsShortName>
+                            <BitsName>Time Offset for POS and GA.</BitsName>
+                            <BitsPresence>6</BitsPresence>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>XP</BitsShortName>
+                            <BitsName>X Pulse Presence</BitsName>
+                            <BitsPresence>7</BitsPresence>
+                        </Bits>
+                        <Bits bit="1" fx="1">
+                            <BitsShortName>FX</BitsShortName>
+                            <BitsName>Extension Indicator</BitsName>
+							<BitsValue val="0">End of Data Item</BitsValue>
+							<BitsValue val="1">Extension into first extent</BitsValue>
+                        </Bits>
+                    </Fixed>
+				</Variable>
+                    <Fixed length="1">
+                        <Bits bit="8">
+                            <BitsShortName>M5</BitsShortName>
+                            <BitsValue val="0">No Mode 5 interrogation</BitsValue>
+                            <BitsValue val="1">Mode 5 interrogation</BitsValue>
+                        </Bits>
+                        <Bits bit="7">
+                            <BitsShortName>ID</BitsShortName>
+                            <BitsValue val="0">No authenticated Mode 5 ID reply</BitsValue>
+                            <BitsValue val="1">Authenticated Mode 5 ID reply</BitsValue>
+                        </Bits>
+                        <Bits bit="6">
+                            <BitsShortName>DA</BitsShortName>
+                            <BitsValue val="0">No authenticated Mode 5 Data reply or Report</BitsValue>
+                            <BitsValue val="1">Authenticated Mode 5 Data reply or Report (i.e any valid Mode 5 reply type other than ID)</BitsValue>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>M1</BitsShortName>
+                            <BitsValue val="0">Mode 1 code not present or not from Mode 5 reply</BitsValue>
+                            <BitsValue val="1">Mode 1 code from Mode 5 reply</BitsValue>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>M2</BitsShortName>
+                            <BitsValue val="0">Mode 2 code not present or not from Mode 5 reply</BitsValue>
+                            <BitsValue val="1">Mode 2 code from Mode 5 reply</BitsValue>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>M3</BitsShortName>
+                            <BitsValue val="0">Mode 3 code not present or not from Mode 5 reply</BitsValue>
+                            <BitsValue val="1">Mode 3 code from Mode 5 reply</BitsValue>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>MC</BitsShortName>
+                            <BitsValue val="0">Mode C altitude not present or not from Mode 5 reply</BitsValue>
+                            <BitsValue val="1">Mode C altitude from Mode 5 reply</BitsValue>
+                        </Bits>
+                        <Bits bit="1">
+                            <BitsShortName>X</BitsShortName>
+                            <BitsName>X-pulse from Mode 5 Data reply or Report.</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no authenticated Data reply or Report received.</BitsValue>
+                            <BitsValue val="1">X-pulse set to one.</BitsValue>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="4">
+                        <Bits from="31" to="32">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="17" to="30">
+                            <BitsShortName>PIN</BitsShortName>
+                            <BitsName>PIN Code</BitsName>
+                        </Bits>
+                        <Bits from="14" to="16">
+							<BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="9" to="13">
+                            <BitsShortName>NAT</BitsShortName>
+                            <BitsName>National Origin</BitsName>
+                        </Bits>
+                        <Bits from="7" to="8">
+							<BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="1" to="6">
+                            <BitsShortName>MIS</BitsShortName>
+                            <BitsName>Mission Code</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="6">
+                        <Bits from="25" to="48" encode="signed">
+							<BitsShortName>Lat</BitsShortName>
+							<BitsName>Latitude in WGS.84 in two’s complement. Range -90 ≤ latitude ≤ 90 deg.</BitsName>
+                            <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                        </Bits>
+                        <Bits from="1" to="24" encode="signed">
+							<BitsShortName>Lon</BitsShortName>
+							<BitsName>Longitude in WGS.84 in two’s complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
+                            <BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits bit="16">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bit set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="15">
+                            <BitsShortName>RES</BitsShortName>
+                            <BitsName>Resolution with which the GNSS-derived Altitude (GA) is reported.</BitsName>
+                            <BitsValue val="0">GA reported in 100 ft increments,</BitsValue>
+                            <BitsValue val="1">GA reported in 25 ft increments.</BitsValue>
+                        </Bits>
+                        <Bits from="1" to="14" encode="signed">
+                            <BitsShortName>GA</BitsShortName>
+                            <BitsName>GNSS-derived Altitude of target, expressed as height above WGS 84 ellipsoid.</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="2">
+                        <Bits from="13" to="16">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits from="1" to="12" encode="octal">
+                            <BitsShortName>EM1</BitsShortName>
+                            <BitsName>Extended Mode 1 Code in octal representation</BitsName>
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="1" to="8" encode="signed">
+                            <BitsShortName>TOS</BitsShortName>
+                            <BitsName>Time Offset coded as a twos complement number with an LSB of 1/128 s. The time at which the Mode 5 Reported Position (Subfield #3) and Mode 5 GNSSderived Altitude (Subfield #4) are valid is given by Time of Day (I048/140) plus Time Offset.</BitsName>
+                            <BitsUnit scale="0.0078125">s</BitsUnit>						
+                        </Bits>
+                    </Fixed>
+                    <Fixed length="1">
+                        <Bits from="6" to="8">
+                            <BitsShortName>spare</BitsShortName>
+                            <BitsName>spare bits set to 0</BitsName>
+                            <BitsConst>0</BitsConst>
+                        </Bits>
+                        <Bits bit="5">
+                            <BitsShortName>X5</BitsShortName>
+                            <BitsName>X-pulse from Mode 5 Data reply or Report.</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no authenticated Data reply or Report received.</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present).</BitsValue>
+                        </Bits>
+                        <Bits bit="4">
+                            <BitsShortName>XC</BitsShortName>
+                            <BitsName>X-pulse from Mode C reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode C reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="3">
+                            <BitsShortName>X3</BitsShortName>
+                            <BitsName>X-pulse from Mode 3/A reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 3/A reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="2">
+                            <BitsShortName>X2</BitsShortName>
+                            <BitsName>X-pulse from Mode 2 reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 2 reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                        <Bits bit="1">
+                            <BitsShortName>X1</BitsShortName>
+                            <BitsName>X-pulse from Mode 1 reply</BitsName>
+                            <BitsValue val="0">X-pulse set to zero or no Mode 1 reply</BitsValue>
+                            <BitsValue val="1">X-pulse set to one (present)</BitsValue>
+                        </Bits>
+                    </Fixed>
+			</Compound>
+		</DataItemFormat>
+	</DataItem>
+	
+	<DataItem id="120" rule="optional">
+		<DataItemName>Track Mode 2 Code</DataItemName>
+		<DataItemDefinition>Mode 2 code associated to the track</DataItemDefinition>
+		<DataItemFormat desc="Two-Octet fixed length data item">
+			<Fixed length="2">
+				<Bits from="13" to="16">
+					<BitsShortName>spare</BitsShortName>
+					<BitsName>Spare bits set to zero</BitsName>
+					<BitsConst>0</BitsConst>
+				</Bits>
+				<Bits from="1" to="12" encode="octal">
+					<BitsShortName>Mode2</BitsShortName>
+					<BitsName>Mode-2 code in octal representation</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+	</DataItem>
+	
+	<DataItem id="130" rule="optional">
+		<DataItemName>Calculated Track Geometric Altitude</DataItemName>
+		<DataItemDefinition>Vertical distance between the target and the projection of its position on the earth’s ellipsoid, as defined by WGS84, in two’s complement form.</DataItemDefinition>
+		<DataItemFormat desc="Two-Octet fixed length data item">
+			<Fixed length="2">
+				<Bits from="1" to="16" encode="signed">
+					<BitsShortName>Alt</BitsShortName>
+					<BitsName>Altitude</BitsName>
+					<BitsUnit scale="6.25" min="-1500" max="150000">ft</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>1. LSB is required to be less than 10 ft by ICAO 2. The source of altitude is identified in bits (SRC) of item I062/080 Track Status</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="135" rule="optional">
+		<DataItemName>Calculated Track Barometric Altitude</DataItemName>
+		<DataItemDefinition>Calculated Barometric Altitude of the track, in two’s complement form.</DataItemDefinition>
+		<DataItemFormat desc="Two-Octet fixed length data item">
+			<Fixed length="2">
+				<Bits bit="16">
+					<BitsShortName>QNH</BitsShortName>
+					<BitsName>QNH</BitsName>
+					<BitsValue val="0">No QNH correction applied</BitsValue>
+					<BitsValue val="1">QNH correction applied</BitsValue>
+				</Bits>
+				<Bits from="1" to="15" encode="signed">
+					<BitsShortName>CTBA</BitsShortName>
+					<BitsName>Calculated Track Barometric Alt</BitsName>
+					<BitsUnit scale="25" min="-1500" max="150000">ft</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>ICAO specifies a range between –10 FL and 1267 FL for Mode C</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="136" rule="optional">
+		<DataItemName>Measured Flight Level</DataItemName>
+		<DataItemDefinition>Last valid and credible flight level used to update the track, in two’s complement form,.</DataItemDefinition>
+		<DataItemFormat desc="Two-Octet fixed length data item">
+			<Fixed length="2">
+				<Bits from="1" to="16" encode="signed">
+					<BitsShortName>MFL</BitsShortName>
+					<BitsName>Measured Flight Level</BitsName>
+					<BitsUnit scale="25" min="-1500" max="150000">ft</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>1. The criteria to determine the credibility of the flight level are Tracker dependent. 2. Credible means: within reasonable range of change with respect to the previous detection. 3. ICAO specifies a range between –10 FL and 1267 FL for Mode C 4. This item includes the barometric altitude received from ADS-B</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="185" rule="optional">
+		<DataItemName>Calculated Track Velocity (Cartesian)</DataItemName>
+		<DataItemDefinition>Calculated track velocity expressed in Cartesian co-ordinates, in two’s complement form.</DataItemDefinition>
+		<DataItemFormat desc="Four-octet fixed length Data Item .">
+			<Fixed length="4">
+				<Bits from="32" to="17" encode="signed">
+					<BitsShortName>Vx</BitsShortName>
+					<BitsName>Vx</BitsName>
+					<BitsUnit scale="0.25" min="-8192" max="8191.75">m/s</BitsUnit>
+				</Bits>
+				<Bits from="16" to="1" encode="signed">
+					<BitsShortName>Vy</BitsShortName>
+					<BitsName>Vy</BitsName>
+					<BitsUnit scale="0.25" min="-8192" max="8191.75">m/s</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>The y-axis points to the Geographical North at the location of the target.</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="200" rule="optional">
+		<DataItemName>Mode of Movement</DataItemName>
+		<DataItemDefinition>Calculated Mode of Movement of a target.</DataItemDefinition>
+		<DataItemFormat desc="One-Octet fixed length data item.">
+			<Fixed length="1">
+				<Bits from="8" to="7">
+					<BitsShortName>TRANSA</BitsShortName>
+					<BitsName>Transversal Acceleration</BitsName>
+					<BitsValue val="0">Constant Course</BitsValue>
+					<BitsValue val="1">Right Turn</BitsValue>
+					<BitsValue val="2">Left Turn</BitsValue>
+					<BitsValue val="3">Undetermined</BitsValue>
+				</Bits>
+				<Bits from="6" to="5">
+					<BitsShortName>LONGA</BitsShortName>
+					<BitsName>Longitudinal Acceleration</BitsName>
+					<BitsValue val="0">Constant Groundspeed</BitsValue>
+					<BitsValue val="1">Increasing Groundspeed</BitsValue>
+					<BitsValue val="2">Decreasing Groundspeed</BitsValue>
+					<BitsValue val="3">Undetermined</BitsValue>
+				</Bits>
+				<Bits from="4" to="3">
+					<BitsShortName>VERTA</BitsShortName>
+					<BitsName>Vertical Rate</BitsName>
+					<BitsValue val="0">Level</BitsValue>
+					<BitsValue val="1">Climb</BitsValue>
+					<BitsValue val="2">Descent</BitsValue>
+					<BitsValue val="3">Undetermined</BitsValue>
+				</Bits>
+				<Bits bit="2">
+					<BitsShortName>ADF</BitsShortName>
+					<BitsName>Altitude Discrepancy Flag</BitsName>
+					<BitsValue val="0">No altitude discrepancy</BitsValue>
+					<BitsValue val="1">Altitude discrepancy</BitsValue>
+				</Bits>
+				<Bits bit="1">
+					<BitsShortName>spare</BitsShortName>
+					<BitsName>Spare bit set to zero</BitsName>
+					<BitsConst>0</BitsConst>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>The ADF, if set, indicates that a difference has been detected in the altitude information derived from radar as compared to other technologies (such as ADS-B).</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="210" rule="optional">
+		<DataItemName>Calculated Acceleration (Cartesian)</DataItemName>
+		<DataItemDefinition>Calculated Acceleration of the target expressed in Cartesian coordinates, in two’s complement form.</DataItemDefinition>
+		<DataItemFormat desc="Two-octet fixed length Data Item .">
+			<Fixed length="2">
+				<Bits from="16" to="9" encode="signed">
+					<BitsShortName>Ax</BitsShortName>
+					<BitsName>Ax</BitsName>
+					<BitsUnit scale="0.25">m/s2</BitsUnit>
+				</Bits>
+				<Bits from="8" to="1" encode="signed">
+					<BitsShortName>Ay</BitsShortName>
+					<BitsName>Ay</BitsName>
+					<BitsUnit scale="0.25">m/s2</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>1. The y-axis points to the Geographical North at the location of the target. 2. Maximum value means maximum value or above.</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="220" rule="optional">
+		<DataItemName>Calculated Rate Of Climb/Descent)</DataItemName>
+		<DataItemDefinition>Calculated rate of Climb/Descent of an aircraft in two’s complement form.</DataItemDefinition>
+		<DataItemFormat desc="Two-octet fixed length Data Item .">
+			<Fixed length="2">
+				<Bits from="1" to="16" encode="signed">
+					<BitsShortName>RoC</BitsShortName>
+					<BitsName>Rate of Climb/Descent</BitsName>
+					<BitsUnit scale="6.25">ft/min</BitsUnit>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>A positive value indicates a climb, whereas a negative value indicates a descent.</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="245" rule="optional">
+		<DataItemName>Target Identification</DataItemName>
+		<DataItemDefinition>Target (aircraft or vehicle) identification in 8 characters.</DataItemDefinition>
+		<DataItemFormat desc="Seven-octet fixed length Data Item.">
+			<Fixed length="7">
+				<Bits from="56" to="55">
+					<BitsShortName>STI</BitsShortName>
+					<BitsName>STI</BitsName>
+					<BitsValue val="0">Callsign or registration downlinked from target</BitsValue>
+					<BitsValue val="1">Callsign not downlinked from target</BitsValue>
+					<BitsValue val="2">Registration not downlinked from target</BitsValue>
+					<BitsValue val="3">Invalid</BitsValue>
+				</Bits>
+				<Bits from="54" to="49">
+					<BitsShortName>spare</BitsShortName>
+					<BitsName>Spare bits set to zero</BitsName>
+					<BitsConst>0</BitsConst>
+				</Bits>
+				<Bits from="48" to="1" encode="6bitschar">
+					<BitsShortName>TId</BitsShortName>
+					<BitsName>Characters 1-8 (coded on 6 bits each) defining target identification</BitsName>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote>1. For coding, see section 3.8.2.9 of [Ref.3] 2. As the Callsign of the target can already be transmitted (thanks to I062/380 Subfield #25 if downlinked from the aircraft or thanks to I062/390 Subfield #2 if the target is correlated to a flight plan), and in order to avoid confusion at end user’s side, this item SHALL not be used.</DataItemNote>
+	</DataItem>	
+
+	<DataItem id="270" rule="optional">
+		<DataItemName>Target Size and Orientation</DataItemName>
+		<DataItemDefinition>Target size defined as length and width of the detected target, and orientation.</DataItemDefinition>
+		<DataItemFormat desc="Variable length Data Item comprising a first part of one octet, followed by one-octet extents as necessary.">
+			<Variable>
+				<Fixed length="1">
+					<Bits from="2" to="8">
+						<BitsShortName>Len</BitsShortName>
+						<BitsName>Length</BitsName>
+						<BitsUnit scale="1">m</BitsUnit>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsName>Extension indicator</BitsName>
+						<BitsValue val="0">End of Data Item</BitsValue>
+						<BitsValue val="1">Extension into first extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits from="2" to="8">
+						<BitsShortName>ORI</BitsShortName>
+						<BitsName>ORIENTATION</BitsName>
+						<BitsUnit scale="2.8125">deg</BitsUnit>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsName>Extension indicator</BitsName>
+						<BitsValue val="0">End of Data Item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+				<Fixed length="1">
+					<Bits from="2" to="8">
+						<BitsShortName>WIDTH</BitsShortName>
+						<BitsName>WIDTH</BitsName>
+						<BitsUnit scale="1">m</BitsUnit>
+					</Bits>
+					<Bits bit="1" fx="1">
+						<BitsShortName>FX</BitsShortName>
+						<BitsName>Extension indicator</BitsName>
+						<BitsValue val="0">End of Data Item</BitsValue>
+						<BitsValue val="1">Extension into next extent</BitsValue>
+					</Bits>
+				</Fixed>
+			</Variable>
+		</DataItemFormat>
+		<DataItemNote>1. The orientation gives the direction which the target nose is pointing to, relative to the Geographical North. 2. When the length only is sent, the largest dimension is provided.</DataItemNote>
+	</DataItem>	
+	
+	<DataItem id="290" rule="optional">
+		<DataItemName>System Track Update Ages</DataItemName>
+		<DataItemDefinition>Ages of the last plot/local track/target report update for eachsensor type.</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of up to two octets, followed by the indicated subfields.">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>TRK</BitsShortName>
+							<BitsName>Track age</BitsName>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>PSR</BitsShortName>
+							<BitsName>PSR age</BitsName>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>SSR</BitsShortName>
+							<BitsName>SSR age</BitsName>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>MDS</BitsShortName>
+							<BitsName>Mode S age</BitsName>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>ADS</BitsShortName>
+							<BitsName>ADS-C age</BitsName>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>ES</BitsShortName>
+							<BitsName>ADS-B Extended Squitter age</BitsName>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>VDL</BitsShortName>
+							<BitsName>ADS-B VDL Mode 4 age</BitsName>
+							<BitsPresence>7</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>UAT</BitsShortName>
+							<BitsName>ADS-B UAT age</BitsName>
+							<BitsPresence>8</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>LOP</BitsShortName>
+							<BitsName>Loop age</BitsName>
+							<BitsPresence>9</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>MLT</BitsShortName>
+							<BitsName>Multilateration age</BitsName>
+							<BitsPresence>10</BitsPresence>
+						</Bits>
+						<Bits from="5" to="2">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>Spare bits set to 0</BitsName>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>
+				
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>TRK</BitsShortName>
+						<BitsName>Actual track age since first occurence</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>PSR</BitsShortName>
+						<BitsName>Age of the last primary detection used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>SSR</BitsShortName>
+						<BitsName>Age of the last secondary detection used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MDS</BitsShortName>
+						<BitsName>Age of the last Mode S detection used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>ADS</BitsShortName>
+						<BitsName>Age of the last ADS-C report used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>ES</BitsShortName>
+						<BitsName>Age of the last 1090 Extended Squitter ADS-B report used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>VDL</BitsShortName>
+						<BitsName>Age of the last VDL Mode 4 ADS-B report used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>UAT</BitsShortName>
+						<BitsName>Age of the last UAT ADS-B report used to update the track</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>LOP</BitsShortName>
+						<BitsName>Age of the last magnetic loop detection</BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MLT</BitsShortName>
+						<BitsName>Age of the last MLT detection </BitsName>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+			</Compound>
+		</DataItemFormat>
+	</DataItem>	
+	
+	<DataItem id="295" rule="optional">
+		<DataItemName>Track Data Ages</DataItemName>
+		<DataItemDefinition>Ages of the data provided.</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of up to five octets, followed by the indicated subfields.">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>MFL</BitsShortName>
+							<BitsName/>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>MD1</BitsShortName>
+							<BitsName/>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>MD2</BitsShortName>
+							<BitsName/>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>MDA</BitsShortName>
+							<BitsName/>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>MD4</BitsShortName>
+							<BitsName/>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>MD5</BitsShortName>
+							<BitsName/>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>MHG</BitsShortName>
+							<BitsName/>
+							<BitsPresence>7</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>IAS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>8</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>TAS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>9</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>SAL</BitsShortName>
+							<BitsName/>
+							<BitsPresence>10</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>FSS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>11</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>TID</BitsShortName>
+							<BitsName/>
+							<BitsPresence>12</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>COM</BitsShortName>
+							<BitsName/>
+							<BitsPresence>13</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>SAB</BitsShortName>
+							<BitsName/>
+							<BitsPresence>14</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>ACS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>15</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>BVR</BitsShortName>
+							<BitsName/>
+							<BitsPresence>16</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>GVR</BitsShortName>
+							<BitsName/>
+							<BitsPresence>17</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>RAN</BitsShortName>
+							<BitsName/>
+							<BitsPresence>18</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>TAR</BitsShortName>
+							<BitsName/>
+							<BitsPresence>19</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>TAN</BitsShortName>
+							<BitsName/>
+							<BitsPresence>20</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>GSP</BitsShortName>
+							<BitsName/>
+							<BitsPresence>21</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>VUN</BitsShortName>
+							<BitsName/>
+							<BitsPresence>22</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>MET</BitsShortName>
+							<BitsName/>
+							<BitsPresence>23</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>EMC</BitsShortName>
+							<BitsName/>
+							<BitsPresence>24</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>POS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>25</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>GAL</BitsShortName>
+							<BitsName/>
+							<BitsPresence>26</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>PUN</BitsShortName>
+							<BitsName/>
+							<BitsPresence>27</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>MB</BitsShortName>
+							<BitsName/>
+							<BitsPresence>28</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>					
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>IAR</BitsShortName>
+							<BitsName/>
+							<BitsPresence>29</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>MAC</BitsShortName>
+							<BitsName/>
+							<BitsPresence>30</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>BPS</BitsShortName>
+							<BitsName/>
+							<BitsPresence>31</BitsPresence>
+						</Bits>
+						<Bits from="5" to="2">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>Spare bits set to 0</BitsName>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MFL</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MD1</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>	
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MD2</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>	
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MDA</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MD4</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MD5</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MHG</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>IAS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>TAS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>SAL</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>FSS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>TID</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>COM</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>SAB</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>ACS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>BVR</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>GVR</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>RAN</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>TAR</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>TAN</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>GSP</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>VUN</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MET</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>EMC</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>POS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>GAL</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>PUN</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MB</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+			
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>IAR</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+			
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>MAC</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>BPS</BitsShortName>
+						<BitsName/>
+						<BitsUnit scale="0.25">sec</BitsUnit>						
+					</Bits>
+				</Fixed>
+
+								
+				
+			</Compound>
+		</DataItemFormat>
+	</DataItem>	
+	
+	<DataItem id="300" rule="optional">
+		<DataItemName>Vehicle Fleet Identification</DataItemName>
+		<DataItemDefinition>Vehicle fleet identification number.</DataItemDefinition>
+		<DataItemFormat desc="One octet fixed length Data Item.">
+			<Fixed length="1">
+				<Bits from="8" to="1">
+					<BitsShortName>VFI</BitsShortName>
+					<BitsName>VFI</BitsName>
+					<BitsValue val="0">Unknown</BitsValue>
+          <BitsValue val="1">ATC equipment maintenance</BitsValue>
+          <BitsValue val="2">Airport maintenance</BitsValue>
+          <BitsValue val="3">Fire</BitsValue>
+          <BitsValue val="4">Bird scarer</BitsValue>
+          <BitsValue val="5">Snow plough</BitsValue>
+          <BitsValue val="6">Runway sweeper</BitsValue>
+          <BitsValue val="7">Emergency</BitsValue>
+          <BitsValue val="8">Police</BitsValue>
+          <BitsValue val="9">Bus</BitsValue>
+          <BitsValue val="10">Tug (push/tow)</BitsValue>
+          <BitsValue val="11">Grass cutter</BitsValue>
+          <BitsValue val="12">Fuel</BitsValue>
+          <BitsValue val="13">Baggage</BitsValue>
+          <BitsValue val="14">Catering</BitsValue>
+          <BitsValue val="15">Aircraft maintenance</BitsValue>
+          <BitsValue val="16">Flyco (follow me)</BitsValue>
+				</Bits>
+			</Fixed>
+		</DataItemFormat>
+		<DataItemNote/>
+	</DataItem>		
+	
+	<DataItem id="340" rule="optional">
+		<DataItemName>Measured In Data Item Formation</DataItemName>
+		<DataItemDefinition>All measured data related to the last report used to update the track</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of one octet, followed by up to six subfields.">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>SID</BitsShortName>
+							<BitsName>Sensor Identification</BitsName>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>POS</BitsShortName>
+							<BitsName>Measured Position</BitsName>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>HEI</BitsShortName>
+							<BitsName>Measured 3-D Height</BitsName>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>MDC</BitsShortName>
+							<BitsName>Last Measured Mode C code</BitsName>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>MDA</BitsShortName>
+							<BitsName>Last Measured Mode 3/A code</BitsName>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>TYP</BitsShortName>
+							<BitsName>Report Type</BitsName>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						
+						<Bits bit="2">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>Spare bit set to zero</BitsName>
+							<BitsConst>0</BitsConst>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>	
+								
+				<Fixed length="2">
+					<Bits from="16" to="9">
+						<BitsShortName>SAC</BitsShortName>
+						<BitsName>System Area Code</BitsName>
+					</Bits>
+					<Bits from="8" to="1">
+						<BitsShortName>SIC</BitsShortName>
+						<BitsName>System Identification Code</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="4">
+					<Bits from="17" to="32">
+						<BitsShortName>RHO</BitsShortName>
+						<BitsName>Measured distance</BitsName>
+						<BitsUnit scale="0.00390625" max="256">NM</BitsUnit>
+					</Bits>
+					<Bits from="1" to="16">
+						<BitsShortName>THETA</BitsShortName>
+						<BitsName>Measured azimuth</BitsName>
+						<BitsUnit scale="0.0054931640625">deg</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="1" to="16">
+						<BitsShortName>HEIGHT</BitsShortName>
+						<BitsName>Measured 3-D Height</BitsName>
+						<BitsUnit scale="25">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits bit="16">
+						<BitsShortName>CV</BitsShortName>
+						<BitsValue val="0">Code validated</BitsValue>
+						<BitsValue val="1">Code not validated</BitsValue>
+					</Bits>
+					<Bits bit="15">
+						<BitsShortName>CG</BitsShortName>
+						<BitsValue val="0">Default</BitsValue>
+						<BitsValue val="1">Garbled code</BitsValue>
+					</Bits>
+					<Bits from="1" to="14" encode="signed">
+						<BitsShortName>ModeC</BitsShortName>
+						<BitsName>Last Measured Mode C Code</BitsName>
+						<BitsUnit scale="0.25" min="-12" max="1270">FL</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits bit="16">
+						<BitsShortName>V</BitsShortName>
+						<BitsValue val="0">Code validated</BitsValue>
+						<BitsValue val="1">Code not validated</BitsValue>
+					</Bits>
+					<Bits bit="15">
+						<BitsShortName>G</BitsShortName>
+						<BitsValue val="0">Default</BitsValue>
+						<BitsValue val="1">Garbled code</BitsValue>
+					</Bits>
+					<Bits bit="14">
+						<BitsShortName>L</BitsShortName>
+						<BitsValue val="0">MODE 3/A code as derived from the reply of the transponder</BitsValue>
+						<BitsValue val="1">Smoothed MODE 3/A code as provided by a sensor local tracker.</BitsValue>
+					</Bits>
+					<Bits bit="13">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bit set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits from="1" to="12" encode="octal"> 
+						<BitsShortName>Mode3A</BitsShortName>
+						<BitsName>Mode 3/A reply under the form of 4 digits in octal representation</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="6" to="8">
+						<BitsShortName>TYP</BitsShortName>
+						<BitsName>Report Type</BitsName>
+						<BitsValue val="0">No detection</BitsValue>
+						<BitsValue val="1">Single PSR detection</BitsValue>
+						<BitsValue val="2">Single SSR detection</BitsValue>
+						<BitsValue val="3">SSR + PSR detection</BitsValue>
+						<BitsValue val="4">Single ModeS All-Call</BitsValue>
+						<BitsValue val="5">Single ModeS Roll-Call</BitsValue>
+						<BitsValue val="6">ModeS All-Call + PSR</BitsValue>
+						<BitsValue val="7">ModeS Roll-Call +PSR</BitsValue>
+					</Bits>
+					<Bits bit="5">
+						<BitsShortName>SIM</BitsShortName>
+						<BitsValue val="0">Actual target report</BitsValue>
+						<BitsValue val="1">Simulated target report</BitsValue>
+					</Bits>
+					<Bits bit="4">
+						<BitsShortName>RAB</BitsShortName>
+						<BitsValue val="0">Report from aircraft transponder</BitsValue>
+						<BitsValue val="1">Report from field monitor (fixed transponder)</BitsValue>
+					</Bits>
+					<Bits bit="3">
+						<BitsShortName>TST</BitsShortName>
+						<BitsValue val="0">Real target report</BitsValue>
+						<BitsValue val="1">Test target report</BitsValue>
+					</Bits>
+					<Bits from="1" to="2">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bits set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+				</Fixed>
+				
+			</Compound>
+		</DataItemFormat>
+	</DataItem>
+		
+	<DataItem id="380" rule="optional">
+		<DataItemName>Aircraft Derived Data</DataItemName>
+		<DataItemDefinition>Data derived directly by the aircraft</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of up to four octets, followed by the indicated subfields">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>ADR</BitsShortName>
+							<BitsName>Target Address</BitsName>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>ID</BitsShortName>
+							<BitsName>Target Identification</BitsName>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>MHG</BitsShortName>
+							<BitsName>Magnetic Heading</BitsName>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>IAS</BitsShortName>
+							<BitsName>Indicated Airspeed/Mach Number</BitsName>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>TAS</BitsShortName>
+							<BitsName>True Airspeed</BitsName>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>SAL</BitsShortName>
+							<BitsName>Selected Altitude</BitsName>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>FSS</BitsShortName>
+							<BitsName>Final State SelectedAltitude</BitsName>
+							<BitsPresence>7</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>TIS</BitsShortName>
+							<BitsName>Trajectory Intent Status</BitsName>
+							<BitsPresence>8</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>TID</BitsShortName>
+							<BitsName>Trajectory Intent Data</BitsName>
+							<BitsPresence>9</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>COM</BitsShortName>
+							<BitsName>Communications / ACAS Capability and Flight Status</BitsName>
+							<BitsPresence>10</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>SAB</BitsShortName>
+							<BitsName>Status reported by ADS-B</BitsName>
+							<BitsPresence>11</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>ACS</BitsShortName>
+							<BitsName>ACAS Resolution Advisory Report</BitsName>
+							<BitsPresence>12</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>BVR</BitsShortName>
+							<BitsName>Barometric Vertical Rate</BitsName>
+							<BitsPresence>13</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>GVR</BitsShortName>
+							<BitsName>Geometric Vertical Rate</BitsName>
+							<BitsPresence>14</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>RAN</BitsShortName>
+							<BitsName>Roll Angle</BitsName>
+							<BitsPresence>15</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>TAR</BitsShortName>
+							<BitsName>Track Angle Rate</BitsName>
+							<BitsPresence>16</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>TAN</BitsShortName>
+							<BitsName>Track Angle</BitsName>
+							<BitsPresence>17</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>GSP</BitsShortName>
+							<BitsName>Ground Speed</BitsName>
+							<BitsPresence>18</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>VUN</BitsShortName>
+							<BitsName>Velocity Uncertainty</BitsName>
+							<BitsPresence>19</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>MET</BitsShortName>
+							<BitsName>Meteorological Data</BitsName>
+							<BitsPresence>20</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>EMC</BitsShortName>
+							<BitsName>Emitter Category</BitsName>
+							<BitsPresence>21</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>POS</BitsShortName>
+							<BitsName>Position Data</BitsName>
+							<BitsPresence>22</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>GAL</BitsShortName>
+							<BitsName>Geometric Altitude Data</BitsName>
+							<BitsPresence>23</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>PUN</BitsShortName>
+							<BitsName>Position Uncertainty Data</BitsName>
+							<BitsPresence>24</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>MB</BitsShortName>
+							<BitsName>Mode S MB Data</BitsName>
+							<BitsPresence>25</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>IAR</BitsShortName>
+							<BitsName> Indicated Airspeed</BitsName>
+							<BitsPresence>26</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>MAC</BitsShortName>
+							<BitsName>Mach Number</BitsName>
+							<BitsPresence>27</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>BPS</BitsShortName>
+							<BitsName>Barometric Pressure Setting</BitsName>
+							<BitsPresence>28</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>
+				
+				<Fixed length="3">
+					<Bits from="24" to="1">
+						<BitsShortName>ADR</BitsShortName>
+						<BitsName>Target Address</BitsName>
+					</Bits>
+				</Fixed>
+				<Fixed length="6">
+					<Bits from="1" to="48" encode="6bitschar">
+						<BitsShortName>ACID</BitsShortName>
+						<BitsName>Target Identification</BitsName>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>MAH</BitsShortName>
+						<BitsName>Magnetic Heading</BitsName>
+						<BitsUnit scale="0.0054931640625">deg</BitsUnit>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits bit="16">
+						<BitsShortName>IM</BitsShortName>
+						<BitsName>IAS/Mach No</BitsName>
+					               <BitsValue val="0">Air Speed = IAS (LSB 2^-14 NM/s)</BitsValue>
+                    					<BitsValue val="1">Air Speed = Mach (LSB 0.001)</BitsValue>	
+					</Bits>
+			
+					<Bits from="15" to="1">
+						<BitsShortName>AS</BitsShortName>
+						<BitsName>Air Speed</BitsName>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>TAS</BitsShortName>
+						<BitsName>True Air Speed</BitsName>
+						<BitsUnit scale="1" min="0" max="2046">knot</BitsUnit>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits bit="16">
+						<BitsShortName>SAS</BitsShortName>
+						<BitsName>SAS</BitsName>
+					               <BitsValue val="0">No source information provided</BitsValue>
+                    					<BitsValue val="1">Source Information provided</BitsValue>	
+					</Bits>
+					<Bits from="15" to="14">
+						<BitsShortName>SRC</BitsShortName>
+						<BitsName>Source</BitsName>
+						<BitsValue val="0">Unknown</BitsValue>
+                    					<BitsValue val="1">Aircraft Altitude</BitsValue>
+                    					<BitsValue val="2">FCU/MCP Selected Altitude</BitsValue>
+                    					<BitsValue val="3">FMS Selected Altitude</BitsValue>
+					</Bits>
+
+					<Bits from="13" to="1" encode="signed">
+						<BitsShortName>Alt</BitsShortName>
+						<BitsName>Altitude</BitsName>						
+						<BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits bit="16">
+						<BitsShortName>MV</BitsShortName>
+						<BitsName>Manage Vertical Mode</BitsName>
+					               <BitsValue val="0">Not active</BitsValue>
+                    					<BitsValue val="1">Active</BitsValue>	
+					</Bits>
+					<Bits bit="15">
+						<BitsShortName>AH</BitsShortName>
+						<BitsName>Altitude Hold</BitsName>
+					               <BitsValue val="0">Not active</BitsValue>
+                    					<BitsValue val="1">Active</BitsValue>	
+					</Bits>
+					<Bits bit="14">
+						<BitsShortName>AM</BitsShortName>
+						<BitsName>Approach Mode</BitsName>
+					               <BitsValue val="0">Not active</BitsValue>
+                    					<BitsValue val="1">Active</BitsValue>	
+					</Bits>
+					<Bits from="13" to="1" encode="signed">
+						<BitsShortName>Alt</BitsShortName>
+						<BitsName>Altitude</BitsName>	
+				               <BitsUnit scale="25" min="-1300" max="100000">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+				
+					<Bits bit="8">
+						<BitsShortName>NAV</BitsShortName>
+						<BitsName>TID available</BitsName>
+					               <BitsValue val="0">Trajectory Intent Data is available for this aircraft</BitsValue>
+                    					<BitsValue val="1">Trajectory Intent Data is not available for this aircraft</BitsValue>	
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>NVB</BitsShortName>
+						<BitsName>TID valid</BitsName>
+					               <BitsValue val="0">Trajectory Intent Data is valid</BitsValue>
+                    					<BitsValue val="1">Trajectory Intent Data is not valid</BitsValue>	
+					</Bits>
+					<Bits from="6" to="2">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare Bits set to zero</BitsName>
+					</Bits>
+					<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+					</Bits>
+				</Fixed>
+				
+				<Repetitive>
+          <Fixed length="15">
+            <Bits bit="120">
+                <BitsShortName>TCA</BitsShortName>
+							<BitsName>TCP number availability</BitsName>
+                <BitsValue val="0">TCP number available</BitsValue>
+                <BitsValue val="1">TCP number not available</BitsValue>
+            </Bits>
+            <Bits bit="119">
+                <BitsShortName>NC</BitsShortName>
+							<BitsName>TCP compliance</BitsName>
+                <BitsValue val="0">TCP compliance</BitsValue>
+                <BitsValue val="1">TCP non-compliance</BitsValue>
+            </Bits>
+						<Bits from="118" to="113" encode="signed">
+							<BitsShortName>TCPnum</BitsShortName>
+							<BitsName>Trajectory Change Point number</BitsName>
+            </Bits>
+            <Bits from="112" to="97" encode="signed">
+							<BitsShortName>Alt</BitsShortName>
+                <BitsName>Altitude</BitsName>
+                <BitsUnit scale="10" min="-1500" max="150000">ft</BitsUnit>
+            </Bits>
+            <Bits from="96" to="73" encode="signed">
+							<BitsShortName>Lat</BitsShortName>
+							<BitsName>Latitude in WGS.84 in twos complement. Range -90 &lt; Lat &lt; 90 deg.</BitsName>
+                <BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+            </Bits>
+            <Bits from="72" to="49" encode="signed">
+							<BitsShortName>Lon</BitsShortName>
+							<BitsName>Longitude In WGS.84 in twos complement. Range -180 &lt; longitude &lt; 180 deg.</BitsName>
+							<BitsUnit scale="0.000021457672119140625" min="-90" max="90">deg</BitsUnit>
+            </Bits>
+            <Bits from="48" to="45">
+							<BitsShortName>PT</BitsShortName>
+							<BitsName>Point type</BitsName>
+                <BitsValue val="0">Unknown</BitsValue>
+                <BitsValue val="1">Fly by waypoint (LT)</BitsValue>
+                <BitsValue val="2">Fly over waypoint (LT)</BitsValue>
+                <BitsValue val="3">Hold pattern (LT)</BitsValue>
+                <BitsValue val="4">Procedure hold (LT)</BitsValue>
+                <BitsValue val="5">Procedure turn (LT)</BitsValue>
+                <BitsValue val="6">RF leg (LT)</BitsValue>
+                <BitsValue val="7">Top of climb (VT)</BitsValue>
+                <BitsValue val="8">Top of descent (VT)</BitsValue>
+                <BitsValue val="9">Start of level (VT)</BitsValue>
+                <BitsValue val="10">Cross-over altitude (VT)</BitsValue>
+                <BitsValue val="11">Transition altitude (VT)</BitsValue>
+            </Bits>
+            <Bits from="44" to="43">
+                <BitsShortName>TD</BitsShortName>
+							<BitsName>Turn Direction</BitsName>
+                <BitsValue val="0">N/A</BitsValue>
+                <BitsValue val="1">Turn right</BitsValue>
+                <BitsValue val="2">Turn left</BitsValue>
+                <BitsValue val="3">No turn</BitsValue>
+            </Bits>
+            <Bits bit="42">
+                <BitsShortName>TRA</BitsShortName>
+                <BitsName>Turn Radius Availability</BitsName>
+                <BitsValue val="0">TTR not available</BitsValue>
+                <BitsValue val="1">TTR available</BitsValue>
+            </Bits>
+            <Bits bit="41">
+                <BitsShortName>TOA</BitsShortName>
+							<BitsName>TOV available</BitsName>
+                <BitsValue val="0">TOV available</BitsValue>
+                <BitsValue val="1">TOV not available</BitsValue>
+            </Bits>
+						<Bits from="40" to="17" encode="unsigned">
+                <BitsShortName>TOV</BitsShortName>
+                <BitsName>Time Over Point</BitsName>
+                <BitsUnit scale="1">s</BitsUnit>
+            </Bits>
+						<Bits from="16" to="1" encode="unsigned">
+                <BitsShortName>TTR</BitsShortName>
+							<BitsName>Turn radius</BitsName>
+							<BitsUnit scale="0.01" min="0" max="655.35">Nm</BitsUnit>
+            </Bits>
+          </Fixed>
+				</Repetitive>
+				
+				<Fixed length="2">
+					<Bits from="14" to="16">
+						<BitsShortName>COM</BitsShortName>
+						<BitsName>Communications capability of the transponder</BitsName>
+						<BitsValue val="0">No communications capability (surveillance only)</BitsValue>
+						<BitsValue val="1">Comm. A and Comm. B capability</BitsValue>
+						<BitsValue val="2">Comm. A, Comm. B and Uplink ELM</BitsValue>
+						<BitsValue val="3">Comm. A, Comm. B, Uplink ELM and Downlink ELM</BitsValue>
+						<BitsValue val="4">Level 5 Transponder capability</BitsValue>
+						<BitsValue val="5">Not assigned</BitsValue>
+						<BitsValue val="6">Not assigned</BitsValue>
+						<BitsValue val="7">Not assigned</BitsValue>
+					</Bits>
+					<Bits from="11" to="13">
+						<BitsShortName>STAT</BitsShortName>
+						<BitsName>Flight Status</BitsName>
+						<BitsValue val="0">No alert, no SPI, aircraft airborne</BitsValue>
+						<BitsValue val="1">No alert, no SPI, aircraft on ground</BitsValue>
+						<BitsValue val="2">Alert, no SPI, aircraft airborne</BitsValue>
+						<BitsValue val="3">Alert, no SPI, aircraft on ground</BitsValue>
+						<BitsValue val="4">Alert, SPI, aircraft airborne or on ground</BitsValue>
+						<BitsValue val="5">No alert, SPI, aircraft airborne or on ground</BitsValue>
+						<BitsValue val="6">Not assigned</BitsValue>
+						<BitsValue val="7">Not assigned</BitsValue>
+					</Bits>
+					<Bits from="9" to="10">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bits set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits bit="8">
+						<BitsShortName>SSC</BitsShortName>
+						<BitsName>Specific service capability</BitsName>
+						<BitsValue val="0">No</BitsValue>
+						<BitsValue val="1">Yes</BitsValue>
+					</Bits>
+					<Bits bit="7">
+						<BitsShortName>ARC</BitsShortName>
+						<BitsName>Altitude reporting capability</BitsName>
+						<BitsValue val="0">100 ft resolution</BitsValue>
+						<BitsValue val="1">25 ft resolution</BitsValue>
+					</Bits>
+					<Bits bit="6">
+						<BitsShortName>AIC</BitsShortName>
+						<BitsName>Aircraft identification capability</BitsName>
+						<BitsValue val="0">No</BitsValue>
+						<BitsValue val="1">Yes</BitsValue>
+					</Bits>
+					<Bits bit="5">
+						<BitsShortName>B1A</BitsShortName>
+						<BitsName>BDS 1,0 bit 16</BitsName>
+					</Bits>
+					<Bits from="1" to="4">
+						<BitsShortName>B1B</BitsShortName>
+						<BitsName>BDS 1,0 bits 37/40</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="15">
+						<BitsShortName>AC</BitsShortName>
+						<BitsName>ACAS status</BitsName>
+						<BitsValue val="0">unknown</BitsValue>
+						<BitsValue val="1">ACAS not operational</BitsValue>
+						<BitsValue val="2">ACAS operational</BitsValue>
+						<BitsValue val="3">invalid</BitsValue>
+					</Bits>
+					<Bits from="14" to="13">
+						<BitsShortName>MN</BitsShortName>
+						<BitsName>Multiple navigational aids status</BitsName>
+						<BitsValue val="0">unknown</BitsValue>
+						<BitsValue val="1">Multiple navigational aids not operating</BitsValue>
+						<BitsValue val="2">Multiple navigational aids operating</BitsValue>
+						<BitsValue val="3">invalid</BitsValue>
+					</Bits>
+					<Bits from="12" to="11">
+						<BitsShortName>DC</BitsShortName>
+						<BitsName>Differential correction status</BitsName>
+						<BitsValue val="0">unknown</BitsValue>
+						<BitsValue val="1">Differential correction</BitsValue>
+						<BitsValue val="2">No Differential correction</BitsValue>
+						<BitsValue val="3">invalid</BitsValue>
+					</Bits>
+					<Bits bit="10">
+						<BitsShortName>GBS</BitsShortName>
+						<BitsName>Ground Bit Set</BitsName>
+						<BitsValue val="0">Transponder Ground Bit not set or unknown</BitsValue>
+						<BitsValue val="1">Transponder Ground Bit set</BitsValue>
+					</Bits>
+					<Bits from="9" to="4">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bits set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits from="3" to="1">
+						<BitsShortName>STAT</BitsShortName>
+						<BitsName>Flight Status</BitsName>
+						<BitsValue val="0">No emergency</BitsValue>
+						<BitsValue val="1">General emergency</BitsValue>
+						<BitsValue val="2">Lifeguard / medical</BitsValue>
+						<BitsValue val="3">Minimum fuel</BitsValue>
+						<BitsValue val="4">No communications</BitsValue>
+						<BitsValue val="5">Unlawful interference</BitsValue>
+						<BitsValue val="6">“Downed” Aircraft</BitsValue>
+						<BitsValue val="7">Unknown</BitsValue>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="7">
+					<Bits from="56" to="1">
+						<BitsShortName>ACASAD</BitsShortName>
+						<BitsName>ACAS Resolution Advisory Report - BDS 3,0</BitsName>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>BVR</BitsShortName>
+						<BitsName>Barometric Vertical Rate</BitsName>
+						 <BitsUnit scale="6.25">ft/min</BitsUnit>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>GVR</BitsShortName>
+						<BitsName>Geometric Vertical Rate</BitsName>
+						<BitsUnit scale="6.25">ft/min</BitsUnit>
+					</Bits>
+				</Fixed>
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>RAN</BitsShortName>
+						<BitsName>Roll Angle</BitsName>
+						<BitsUnit scale="0.01" min="-180" max="180">deg</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="15">
+						<BitsShortName>TI</BitsShortName>
+						<BitsName>Turn Indicator</BitsName>
+						<BitsValue val="0">Not available</BitsValue>
+						<BitsValue val="1">Left</BitsValue>
+						<BitsValue val="2">Right</BitsValue>
+						<BitsValue val="3">Straight</BitsValue>
+					</Bits>
+					<Bits from="14" to="9">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bits set to zero</BitsName>
+					</Bits>
+					<Bits from="8" to="2" encode="signed">
+						<BitsShortName>RoT</BitsShortName>
+						<BitsName>Rate of Turn</BitsName>
+						<BitsUnit scale="0.25">deg/sec</BitsUnit>
+					</Bits>
+					<Bits bit="1">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bits set to zero</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>TAN</BitsShortName>
+						<BitsName>Track Angle</BitsName>
+						<BitsUnit scale="0.0054931640625">deg</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>GS</BitsShortName>
+						<BitsName>Ground Speed</BitsName>
+						<BitsUnit scale="0.00006103515625" min="-2" max="2">NM/s</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>VUN</BitsShortName>
+						<BitsName>Velocity Uncertainty Category</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="8">
+					<Bits bit="64">
+						<BitsShortName>WS</BitsShortName>
+						<BitsName>Wind Speed Valid</BitsName>
+						<BitsValue val="0">Not Valid</BitsValue>
+						<BitsValue val="1">Valid</BitsValue>
+					</Bits>
+					<Bits bit="63">
+						<BitsShortName>WD</BitsShortName>
+						<BitsName>Wind Direction Valid</BitsName>
+						<BitsValue val="0">Not Valid</BitsValue>
+						<BitsValue val="1">Valid</BitsValue>
+					</Bits>
+					<Bits bit="62">
+						<BitsShortName>TMP</BitsShortName>
+						<BitsName>Temperature Valid</BitsName>
+						<BitsValue val="0">Not Valid</BitsValue>
+						<BitsValue val="1">Valid</BitsValue>
+					</Bits>
+					<Bits bit="61">
+						<BitsShortName>TRB</BitsShortName>
+						<BitsName>Turbulence Valid</BitsName>
+						<BitsValue val="0">Not Valid</BitsValue>
+						<BitsValue val="1">Valid</BitsValue>
+					</Bits>
+					<Bits from="60" to="57">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare Bits set to zero</BitsName>
+					</Bits>
+					<Bits from="56" to="41">
+						<BitsShortName>WS_D</BitsShortName>
+						<BitsName>Wind Speed</BitsName>
+						<BitsUnit scale="1" min="0" max="300">kt</BitsUnit>
+					</Bits>
+					<Bits from="40" to="25">
+						<BitsShortName>WD_D</BitsShortName>
+						<BitsName>Wind Direction</BitsName>
+						<BitsUnit scale="1" min="0" max="360">deg</BitsUnit>
+					</Bits>
+					<Bits from="24" to="9" encode="signed">
+						<BitsShortName>TMP_D</BitsShortName>
+						<BitsName>Temperature</BitsName>
+						<BitsUnit scale="0.25" min="-100" max="100">deg C</BitsUnit>
+					</Bits>
+					<Bits from="8" to="1">
+						<BitsShortName>TRB_D</BitsShortName>
+						<BitsName>Turbulence</BitsName>
+					</Bits>	
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="1">
+						<BitsShortName>ECAT</BitsShortName>
+						<BitsName>Emitter Category</BitsName>
+						<BitsValue val="1">light aircraft less than 7000 kg</BitsValue>
+						<BitsValue val="2">reserved</BitsValue>
+						<BitsValue val="3">more than 7000kg, less than 136000kg</BitsValue>
+						<BitsValue val="4">reserved</BitsValue>
+						<BitsValue val="5">more than 136000kg - heavy aircraft</BitsValue>
+						<BitsValue val="6">highly manoeuvrable (5g acceleration capability) and high speed (more than 400 knots cruise)</BitsValue>
+						<BitsValue val="7">reserved</BitsValue>
+						<BitsValue val="8">reserved</BitsValue>
+						<BitsValue val="9">reserved</BitsValue>
+						<BitsValue val="10">rotocraft</BitsValue>
+						<BitsValue val="11">glider / sailplane</BitsValue>
+						<BitsValue val="12">lighter-than-air</BitsValue>
+						<BitsValue val="13">unmanned aerial vehicle</BitsValue>
+						<BitsValue val="14">space / transatmospheric vehicle</BitsValue>
+						<BitsValue val="15">ultralight / handglider / paraglider</BitsValue>
+						<BitsValue val="16">parachutist / skydiver</BitsValue>
+						<BitsValue val="17">reserved</BitsValue>
+						<BitsValue val="18">reserved</BitsValue>
+						<BitsValue val="19">reserved</BitsValue>
+						<BitsValue val="20">surface emergency vehicle</BitsValue>
+						<BitsValue val="21">surface service vehicle</BitsValue>
+						<BitsValue val="22">fixed ground or tethered obstruction</BitsValue>
+						<BitsValue val="23">reserved</BitsValue>
+						<BitsValue val="24">reserved</BitsValue>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="6">
+					<Bits from="48" to="25" encode="signed">
+						<BitsShortName>Lat</BitsShortName>
+						<BitsName>Latitude in WGS.84 in two’s complement. Range -90 ≤ Lat ≤ 90 deg.</BitsName>
+					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
+				</Bits>
+				<Bits from="24" to="1" encode="signed">
+						<BitsShortName>Lon</BitsShortName>
+						<BitsName>Longitude in WGS.84 in two’s complement. Range -180 ≤ longitude &lt; 180 deg.</BitsName>
+					<BitsUnit scale="0.00000536441802978515625">deg</BitsUnit>
+				</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>GAL</BitsShortName>
+						<BitsName>Geometric Altitude</BitsName>
+						<BitsUnit scale="6.25" min="'1500" max="150000">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="1">
+					<Bits from="8" to="5">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>Spare bits set to zero</BitsName>
+					</Bits>
+					<Bits from="4" to="1">
+						<BitsShortName>PUN</BitsShortName>
+						<BitsName>Position Uncertainty</BitsName>
+					</Bits>
+				</Fixed>
+				
+				<Repetitive>
+				<Fixed length="8">
+					<Bits from="9" to="64">
+							<BitsShortName>MB</BitsShortName>
+						<BitsName>56 bit message conveying Mode S B message data</BitsName>
+					</Bits>
+					<Bits from="5" to="8">
+						<BitsShortName>BDS1</BitsShortName>
+						<BitsName>Comm B data Buffer Store 1 Address</BitsName>
+					</Bits>
+					<Bits from="1" to="4">
+						<BitsShortName>BDS2</BitsShortName>
+						<BitsName>Comm B data Buffer Store 2 Address</BitsName>
+					</Bits>
+				</Fixed>
+				</Repetitive>
+				
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>IAS</BitsShortName>
+						<BitsName>Indicated Air Speed</BitsName>
+						<BitsUnit scale="1" min="'0" max="1100">kt</BitsUnit>
+					</Bits>
+				</Fixed>				
+				<Fixed length="2">
+					<Bits from="16" to="1">
+						<BitsShortName>MNO</BitsShortName>
+						<BitsName>Mach Number</BitsName>
+						<BitsUnit scale="0.008" min="'0" max="4.096">Mach</BitsUnit>
+					</Bits>
+				</Fixed>
+				
+				<Fixed length="2">
+					<Bits from="16" to="13">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bits set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits from="12" to="1">
+						<BitsShortName>BPS</BitsShortName>
+						<BitsName>Barometric Pressure Setting</BitsName>
+						<BitsUnit scale="0.1" min="'0" max="409.6">mbar</BitsUnit>
+					</Bits>
+				</Fixed>
+
+
+			</Compound>
+		</DataItemFormat>
+	</DataItem>
+
+	<DataItem id="390" rule="optional">
+		<DataItemName>Flight Plan Related Data</DataItemName>
+		<DataItemDefinition>All flight plan related information</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of two octets, followed by up to fourteen subfields.">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>TAG</BitsShortName>
+							<BitsName>FPPS Identification Tag</BitsName>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>CSN</BitsShortName>
+							<BitsName>Callsign</BitsName>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>IFI</BitsShortName>
+							<BitsName>IFPS_FLIGHT_ID</BitsName>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>FCT</BitsShortName>
+							<BitsName>Flight Category</BitsName>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>TAC</BitsShortName>
+							<BitsName>Type of Aircraft</BitsName>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>WTC</BitsShortName>
+							<BitsName>Wake Turbulence Category</BitsName>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>DEP</BitsShortName>
+							<BitsName>Departure Airport</BitsName>
+							<BitsPresence>7</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>DST</BitsShortName>
+							<BitsName>Destination Airport</BitsName>
+							<BitsPresence>8</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>RDS</BitsShortName>
+							<BitsName>Runway Designation</BitsName>
+							<BitsPresence>9</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>CFL</BitsShortName>
+							<BitsName>Current Cleared Flight Level</BitsName>
+							<BitsPresence>10</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>CTL</BitsShortName>
+							<BitsName>Current Control Position</BitsName>
+							<BitsPresence>11</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>TOD</BitsShortName>
+							<BitsName>Time of Departure</BitsName>
+							<BitsPresence>12</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>AST</BitsShortName>
+							<BitsName>Aircraft Stand</BitsName>
+							<BitsPresence>13</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>STS</BitsShortName>
+							<BitsName>Stand Status</BitsName>
+							<BitsPresence>14</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+          </Fixed>
+          <Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>STD</BitsShortName>
+							<BitsName>Standard Instrument Departure</BitsName>
+							<BitsPresence>15</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>STA</BitsShortName>
+							<BitsName>Standard Instrument Arrival</BitsName>
+							<BitsPresence>16</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>PEM</BitsShortName>
+              <BitsName>Pre-emergency Mode 3/A code</BitsName>
+							<BitsPresence>17</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>PEC</BitsShortName>
+							<BitsName>Pre-emergency Callsign</BitsName>
+							<BitsPresence>18</BitsPresence>
+						</Bits>
+						<Bits from="4" to="2">
+              <BitsShortName>spare</BitsShortName>
+              <BitsName>spare bits set to zero</BitsName>
+              <BitsConst>0</BitsConst>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">no extension</BitsValue>
+							<BitsValue val="1">extension</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>
+				<Fixed length="2">
+					<Bits from="9" to="16">
+						<BitsShortName>SAC</BitsShortName>
+						<BitsName>System Area Code</BitsName>
+					</Bits>
+					<Bits from="1" to="8">
+						<BitsShortName>SIC</BitsShortName>
+						<BitsName>System Identification Code</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="7">
+					<Bits from="1" to="56" encode="ascii">
+						<BitsShortName>CS</BitsShortName>
+						<BitsName>Callsign</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="4">
+					<Bits from="31" to="32">
+						<BitsShortName>TYP</BitsShortName>
+						<BitsValue val="0">Plan Number</BitsValue>
+						<BitsValue val="1">Unit 1 internal flight number</BitsValue>
+						<BitsValue val="2">Unit 2 internal flight number</BitsValue>
+						<BitsValue val="3">Unit 3 internal flight number</BitsValue>
+					</Bits>
+					<Bits from="28" to="30">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bits set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+					<Bits from="1" to="27" encode="unsigned">
+						<BitsShortName>NBR</BitsShortName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="1">
+					<Bits from="7" to="8">
+						<BitsShortName>GATOAT</BitsShortName>
+						<BitsValue val="0">Unknown</BitsValue>
+						<BitsValue val="1">General Air Traffic</BitsValue>
+						<BitsValue val="2">Operational Air Traffic</BitsValue>
+						<BitsValue val="3">Not applicable</BitsValue>
+					</Bits>
+					<Bits from="5" to="6">
+						<BitsShortName>FR1FR2</BitsShortName>
+						<BitsValue val="0">Instrument Flight Rules</BitsValue>
+						<BitsValue val="1">Visual Flight rules</BitsValue>
+						<BitsValue val="2">Not applicable</BitsValue>
+						<BitsValue val="3">Controlled Visual Flight Rules</BitsValue>
+					</Bits>
+					<Bits from="3" to="4">
+						<BitsShortName>RVSM</BitsShortName>
+						<BitsValue val="0">Unknown</BitsValue>
+						<BitsValue val="1">Approved</BitsValue>
+						<BitsValue val="2">Exempt</BitsValue>
+						<BitsValue val="3">Not Approved</BitsValue>
+					</Bits>
+					<Bits bit="2">
+						<BitsShortName>HPR</BitsShortName>
+						<BitsValue val="0">Normal Priority Flight</BitsValue>
+						<BitsValue val="1">High Priority Flight</BitsValue>
+					</Bits>
+					<Bits bit="1">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bit set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+				</Fixed>				
+				<Fixed length="4">
+					<Bits from="1" to="32" encode="ascii">
+						<BitsShortName>TYPE</BitsShortName>
+						<BitsName>Type of Aircraft</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="1">
+					<Bits from="8" to="1" encode="ascii">
+						<BitsShortName>WTC</BitsShortName>
+						<BitsName>Wake Turbulence Category</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="4">
+					<Bits from="32" to="1" encode="ascii">
+						<BitsShortName>DEP</BitsShortName>
+						<BitsName>Departure Airport</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="4">
+					<Bits from="1" to="32" encode="ascii">
+						<BitsShortName>DES</BitsShortName>
+						<BitsName>Destination Airport</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="3">
+					<Bits from="17" to="24" encode="ascii">
+						<BitsShortName>NU1</BitsShortName>
+						<BitsName>First number</BitsName>
+					</Bits>
+					<Bits from="9" to="16" encode="ascii">
+						<BitsShortName>NU2</BitsShortName>
+						<BitsName>Second number</BitsName>
+					</Bits>
+					<Bits from="1" to="8" encode="ascii">
+						<BitsShortName>LTR</BitsShortName>
+						<BitsName>Letter</BitsName>
+					</Bits>
+				</Fixed>				
+				<Fixed length="2">
+					<Bits from="1" to="16" encode="unsigned">
+						<BitsShortName>CFL</BitsShortName>
+						<BitsName>Current Cleared Flight Level</BitsName>
+						<BitsUnit scale=".25">FL</BitsUnit>
+
+					</Bits>
+				</Fixed>				
+				<Fixed length="2">
+					<Bits from="9" to="16" encode="unsigned">
+						<BitsShortName>Centre</BitsShortName>
+						<BitsName>8-bit group Identification code</BitsName>
+					</Bits>
+					<Bits from="1" to="8" encode="unsigned">
+						<BitsShortName>Position</BitsShortName>
+						<BitsName>8-bit Control Position identification code</BitsName>
+					</Bits>
+				</Fixed>	
+				<Repetitive>
+					<Fixed length="4">
+						<Bits from="28" to="32">
+							<BitsShortName>TYP</BitsShortName>
+							<BitsValue val="0">Scheduled off-block time</BitsValue>
+							<BitsValue val="1">Estimated off-block time</BitsValue>
+							<BitsValue val="2">Estimated take-off time</BitsValue>
+							<BitsValue val="3">Actual off-block time</BitsValue>
+							<BitsValue val="4">Predicted time at runway hold</BitsValue>
+							<BitsValue val="5">Actual time at runway hold</BitsValue>
+							<BitsValue val="6">Actual line-up time</BitsValue>
+							<BitsValue val="7">Actual take-off time</BitsValue>
+							<BitsValue val="8">Estimated time of arrival</BitsValue>
+							<BitsValue val="9">Predicted landing time</BitsValue>
+							<BitsValue val="10">Actual landing time</BitsValue>
+							<BitsValue val="11">Actual time off runway</BitsValue>
+							<BitsValue val="12">Predicted time to gate</BitsValue>
+							<BitsValue val="13">Actual on-block time</BitsValue>
+						</Bits>
+						<Bits from="26" to="27">
+							<BitsShortName>DAY</BitsShortName>
+							<BitsValue val="0">Today</BitsValue>
+							<BitsValue val="1">Yesterday</BitsValue>
+							<BitsValue val="2">Tomorrow</BitsValue>
+							<BitsValue val="3">Invalid</BitsValue>
+						</Bits>
+						<Bits from="22" to="25">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>spare bits set to zero</BitsName>
+							<BitsConst>0</BitsConst>
+						</Bits>
+						<Bits from="17" to="21">
+							<BitsShortName>HOR</BitsShortName>
+							<BitsName>Hours, from 0 to 23</BitsName>
+						</Bits>
+						<Bits from="15" to="16">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>spare bits set to zero</BitsName>
+							<BitsConst>0</BitsConst>
+						</Bits>
+						<Bits from="9" to="14">
+							<BitsShortName>MIN</BitsShortName>
+							<BitsName>Minutes, from 0 to 59</BitsName>
+						</Bits>
+						<Bits bit="8">
+							<BitsShortName>AVS</BitsShortName>
+							<BitsValue val="0">Seconds available</BitsValue>
+							<BitsValue val="1">Seconds not available</BitsValue>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>spare bit set to zero</BitsName>
+							<BitsConst>0</BitsConst>
+						</Bits>
+						<Bits from="1" to="6">
+							<BitsShortName>SEC</BitsShortName>
+							<BitsName>Seconds, from 0 to 59</BitsName>
+						</Bits>
+					</Fixed>
+				</Repetitive>
+				<Fixed length="6">
+					<Bits from="1" to="48" encode="ascii">
+						<BitsShortName>AS</BitsShortName>
+						<BitsName>Aircraft Stand</BitsName>
+					</Bits>
+				</Fixed>	
+				<Fixed length="1">
+					<Bits from="7" to="8">
+						<BitsShortName>EMP</BitsShortName>
+						<BitsValue val="0">Empty</BitsValue>
+						<BitsValue val="1">Occupied</BitsValue>
+						<BitsValue val="2">Unknown</BitsValue>
+						<BitsValue val="3">Invalid</BitsValue>
+					</Bits>
+					<Bits from="5" to="6">
+						<BitsShortName>AVL</BitsShortName>
+						<BitsValue val="0">Available</BitsValue>
+						<BitsValue val="1">Not available</BitsValue>
+						<BitsValue val="2">Unknown</BitsValue>
+						<BitsValue val="3">Invalid</BitsValue>
+					</Bits>
+					<Bits from="1" to="4">
+						<BitsShortName>spare</BitsShortName>
+						<BitsName>spare bit set to zero</BitsName>
+						<BitsConst>0</BitsConst>
+					</Bits>
+				</Fixed>
+        <Fixed length="7">
+					<Bits from="1" to="56" encode="ascii">
+            <BitsShortName>SID</BitsShortName>
+            <BitsName>Standard Instrument Departure</BitsName>
+          </Bits>
+        </Fixed>
+        <Fixed length="7">
+					<Bits from="1" to="56" encode="ascii">
+            <BitsShortName>STAR</BitsShortName>
+            <BitsName>Standard Instrument Arrival</BitsName>
+          </Bits>
+        </Fixed>
+        <Fixed length="2">
+          <Bits from="16" to="14">
+            <BitsShortName>spare</BitsShortName>
+            <BitsName>spare bit set to zero</BitsName>
+            <BitsConst>0</BitsConst>
+          </Bits>
+          <Bits bit="13">
+						<BitsShortName>VAL</BitsShortName>
+            <BitsName>Validity</BitsName>
+            <BitsValue val="0">No valid Mode 3/A available</BitsValue>
+            <BitsValue val="1">Valid Mode 3/A available</BitsValue>
+          </Bits>
+          <Bits from="12" to="1" encode="octal">
+						<BitsShortName>PEM</BitsShortName>
+						<BitsName>Pre-emergency Mode 3A code</BitsName>
+          </Bits>
+        </Fixed>
+        <Fixed length="7">
+					<Bits from="1" to="56" encode="ascii">
+						<BitsShortName>PAC</BitsShortName>
+						<BitsName>Pre-emergency Callsign</BitsName>
+          </Bits>
+        </Fixed>
+    </Compound>
+		</DataItemFormat>
+	</DataItem>
+	
+	<DataItem id="500" rule="optional">
+
+		<DataItemName>Estimated Accuracies</DataItemName>
+		<DataItemDefinition>Overview of all important accuracies</DataItemDefinition>
+		<DataItemFormat desc="Compound Data Item, comprising a primary subfield of two octets, followed by up to eight subfields of predefined length.">
+			<Compound>
+				<Variable>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>APC</BitsShortName>
+							<BitsName>Estimated Accuracy Of Track Position Cartesian</BitsName>
+							<BitsPresence>1</BitsPresence>
+						</Bits>
+						<Bits bit="7">
+							<BitsShortName>COV</BitsShortName>
+							<BitsName>XY Covariance</BitsName>
+							<BitsPresence>2</BitsPresence>
+						</Bits>
+						<Bits bit="6">
+							<BitsShortName>APW</BitsShortName>
+							<BitsName>Estimated Accuracy Of Track Position WGS-84</BitsName>
+							<BitsPresence>3</BitsPresence>
+						</Bits>
+						<Bits bit="5">
+							<BitsShortName>AGA</BitsShortName>
+							<BitsName>Estimated Accuracy Of Calculated Track Geometric Altitude</BitsName>
+							<BitsPresence>4</BitsPresence>
+						</Bits>
+						<Bits bit="4">
+							<BitsShortName>ABA</BitsShortName>
+							<BitsName>Estimated Accuracy Of Calculated Track Barometric Altitude</BitsName>
+							<BitsPresence>5</BitsPresence>
+						</Bits>
+						<Bits bit="3">
+							<BitsShortName>ATV</BitsShortName>
+							<BitsName>Estimated Accuracy Of Track Velocity Cartesian</BitsName>
+							<BitsPresence>6</BitsPresence>
+						</Bits>
+						<Bits bit="2">
+							<BitsShortName>AA</BitsShortName>
+							<BitsName>Estimated Accuracy Of Acceleration Cartesian</BitsName>
+							<BitsPresence>7</BitsPresence>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">End of Primary Subfield</BitsValue>
+							<BitsValue val="1">Extension into next Octet</BitsValue>
+						</Bits>
+					</Fixed>
+					<Fixed length="1">
+						<Bits bit="8">
+							<BitsShortName>ARC</BitsShortName>
+							<BitsName>Estimated Accuracy Of Rate Of Climb/Descent</BitsName>
+							<BitsPresence>8</BitsPresence>
+						</Bits>
+						<Bits from="2" to="7">
+							<BitsShortName>spare</BitsShortName>
+							<BitsName>Spare bits set to 0</BitsName>
+							<BitsConst>0</BitsConst>
+						</Bits>
+						<Bits bit="1" fx="1">
+							<BitsShortName>FX</BitsShortName>
+							<BitsName>Extension indicator</BitsName>
+							<BitsValue val="0">End of Primary Subfield</BitsValue>
+							<BitsValue val="1">Extension into next Octet</BitsValue>
+						</Bits>
+					</Fixed>
+				</Variable>
+
+				<Fixed length="4">
+					<Bits from="32" to="17">
+						<BitsShortName>APC_X</BitsShortName>
+						<BitsName>Estimated accuracy i.e. standard deviation of the calculated position of an aircraft expressed in Cartesian co-ordinates</BitsName>
+						<BitsUnit scale="0.5">m</BitsUnit>
+					</Bits>
+					<Bits from="16" to="1">
+						<BitsShortName>APC_Y</BitsShortName>
+						<BitsName>Estimated accuracy i.e. standard deviation of the calculated position of an aircraft expressed in Cartesian co-ordinates</BitsName>
+						<BitsUnit scale="0.5">m</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="2">
+					<Bits from="16" to="1" encode="signed">
+						<BitsShortName>COV_XY</BitsShortName>
+						<BitsName>XY covariance component</BitsName>
+						<BitsUnit scale="0.5">m</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="4">
+					<Bits from="17" to="32">
+						<BitsShortName>APW_Lat</BitsShortName>
+						<BitsName>APW Latitude Component</BitsName>
+						<BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+					</Bits>
+					<Bits from="1" to="16">
+						<BitsShortName>APW_Long</BitsShortName>
+						<BitsName>APW Longitude Component</BitsName>
+						<BitsUnit scale="0.000021457672119140625">deg</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="1" to="8">
+						<BitsShortName>AGA_Acc</BitsShortName>
+						<BitsName>Calculated Track Geometric Altitude Estimated accuracy</BitsName>
+						<BitsUnit scale="6.25">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="1">
+					<Bits from="1" to="8">
+						<BitsShortName>ABA_Acc</BitsShortName>
+						<BitsName>Calculated Track Barometric Altitude Estimated accuracy</BitsName>
+						<BitsUnit scale="6.25">ft</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="2">
+					<Bits from="16" to="9">
+						<BitsShortName>ATV_X</BitsShortName>
+						<BitsName>Estimated Accuracy Of Track Velocity X_Cartesian</BitsName>
+						<BitsUnit scale="0.25">m/s</BitsUnit>
+					</Bits>
+					<Bits from="8" to="1">
+						<BitsShortName>ATV_Y</BitsShortName>
+						<BitsName>Estimated Accuracy Of Track Velocity Y_Cartesian</BitsName>
+						<BitsUnit scale="0.25">m/s</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				<Fixed length="2">
+					<Bits from="16" to="9">
+						<BitsShortName>AA_X</BitsShortName>
+						<BitsName>Estimated Accuracy Of Acceleration X_Cartesian</BitsName>
+						<BitsUnit scale="0.25">m/s^2</BitsUnit>
+					</Bits>
+					<Bits from="8" to="1">
+						<BitsShortName>AA_Y</BitsShortName>
+						<BitsName>Estimated Accuracy Of Acceleration Y_Cartesian</BitsName>
+						<BitsUnit scale="0.25">m/s^2</BitsUnit>
+					</Bits>
+				</Fixed>							
+
+				<Fixed length="1">
+					<Bits from="1" to="8">
+						<BitsShortName>ARC_Acc</BitsShortName>
+						<BitsName>Rate Of Climb/Descent Estimated accuracy</BitsName>
+						<BitsUnit scale="6.25">ft/min</BitsUnit>
+					</Bits>
+				</Fixed>
+
+				</Compound>
+		</DataItemFormat>
+	</DataItem>
+
+	<DataItem id="510" rule="optional">
+		<DataItemName>Composed Track Number</DataItemName>
+		<DataItemDefinition>Identification of a system track</DataItemDefinition>
+		<DataItemFormat desc="Extendible data item, comprising a first part of three octets (Master Track Number), followed by three-octet extents (Slave Tracks Numbers).">
+		<Variable>
+			<Fixed length="3">
+				<Bits from="17" to="24">
+					<BitsShortName>SDPSUID</BitsShortName>
+					<BitsName>SDPS UNIT IDENTIFICATION</BitsName>
+				</Bits>
+				<Bits from="2" to="16">
+					<BitsShortName>STN</BitsShortName>
+					<BitsName>SYSTEM TRACK NUMBER</BitsName>
+				</Bits>
+				<Bits bit="1" fx="1">
+					<BitsShortName>FX</BitsShortName>
+					<BitsValue val="0">end of data item</BitsValue>
+					<BitsValue val="1">extension into next extent</BitsValue>
+				</Bits>
+			</Fixed>
+			<Fixed length="3">
+				<Bits from="17" to="24">
+					<BitsShortName>SDPSUID</BitsShortName>
+					<BitsName>SDPS UNIT IDENTIFICATION</BitsName>
+				</Bits>
+				<Bits from="2" to="16">
+					<BitsShortName>STN</BitsShortName>
+					<BitsName>SYSTEM TRACK NUMBER</BitsName>
+				</Bits>
+				<Bits bit="1" fx="1">
+					<BitsShortName>FX</BitsShortName>
+					<BitsValue val="0">end of data item</BitsValue>
+					<BitsValue val="1">extension into next extent</BitsValue>
+				</Bits>
+			</Fixed>
+		</Variable>
+		</DataItemFormat>
+	</DataItem>
+
+	<DataItem id="SP" >
+			<DataItemName>SP Field</DataItemName>
+			<DataItemDefinition>Sp Field</DataItemDefinition>
+			<DataItemFormat desc="Sp Field">
+			<Explicit>
+					<Fixed length="1">
+						<Bits from="8" to="1" encode="hex">
+						<BitsShortName>TRI</BitsShortName>						
+							<BitsName>TargetReportIdentifier</BitsName>						
+						</Bits>
+					</Fixed>
+			</Explicit>
+		</DataItemFormat>
+	</DataItem>		
+<!--Special Purpose Field - ARTAS specific - [LEN-1Byte][RepetitionFactor-1Byte]*[TargetReportIdentifier-4Bytes]
+	<DataItem id="SP" >
+				<Explicit desc="SP Field">
+					<Repetitive>
+						<Fixed length="4">
+							<Bits from="32" to="1" encode="hex">
+								<BitsName>SP Byte</BitsName>						
+							</Bits>
+						</Fixed>
+					</Repetitive>
+				</Explicit>
+	</DataItem>				
+--> 	
+	
+	<UAP>
+		<UAPItem bit="0" frn="1" len="2">010</UAPItem>
+		<UAPItem bit="1" frn="2" len="-">-</UAPItem>
+		<UAPItem bit="2" frn="3" len="1">015</UAPItem>
+		<UAPItem bit="3" frn="4" len="3">070</UAPItem>
+		<UAPItem bit="4" frn="5" len="8">105</UAPItem>
+		<UAPItem bit="5" frn="6" len="6">100</UAPItem>
+		<UAPItem bit="6" frn="7" len="4">185</UAPItem>
+		<UAPItem bit="7" frn="FX" len="-">-</UAPItem>
+		<UAPItem bit="8" frn="8" len="2">210</UAPItem>
+		<UAPItem bit="9" frn="9" len="2">060</UAPItem>
+		<UAPItem bit="10" frn="10" len="7">245</UAPItem>
+		<UAPItem bit="11" frn="11" len="1+">380</UAPItem>
+		<UAPItem bit="12" frn="12" len="2">040</UAPItem>
+		<UAPItem bit="13" frn="13" len="1+">080</UAPItem>
+		<UAPItem bit="14" frn="14" len="1+">290</UAPItem>
+		<UAPItem bit="15" frn="FX" len="-">-</UAPItem>
+		<UAPItem bit="16" frn="15" len="1">200</UAPItem>
+		<UAPItem bit="17" frn="16" len="1+">295</UAPItem>
+		<UAPItem bit="18" frn="17" len="2">136</UAPItem>
+		<UAPItem bit="19" frn="18" len="2">130</UAPItem>
+		<UAPItem bit="20" frn="19" len="2">135</UAPItem>
+		<UAPItem bit="21" frn="20" len="2">220</UAPItem>
+		<UAPItem bit="22" frn="21" len="1+">390</UAPItem>
+		<UAPItem bit="23" frn="FX" len="-">-</UAPItem>
+		<UAPItem bit="24" frn="22" len="1+">270</UAPItem>
+		<UAPItem bit="25" frn="23" len="1">300</UAPItem>
+		<UAPItem bit="26" frn="24" len="1+">110</UAPItem>
+		<UAPItem bit="27" frn="25" len="2">120</UAPItem>
+		<UAPItem bit="28" frn="26" len="3+">510</UAPItem>
+		<UAPItem bit="29" frn="27" len="1+">500</UAPItem>
+		<UAPItem bit="30" frn="28" len="1+">340</UAPItem>
+		<UAPItem bit="31" frn="FX" len="-">-</UAPItem>
+		<UAPItem bit="32" frn="29" len="-">-</UAPItem>
+		<UAPItem bit="33" frn="30" len="-">-</UAPItem>
+		<UAPItem bit="34" frn="31" len="-">-</UAPItem>
+		<UAPItem bit="35" frn="32" len="-">-</UAPItem>
+		<UAPItem bit="36" frn="33" len="-">-</UAPItem>
+		<UAPItem bit="37" frn="34" len="1+">RE</UAPItem>
+		<UAPItem bit="38" frn="35" len="1+1+">SP</UAPItem>
+		<UAPItem bit="39" frn="FX" len="-">-</UAPItem>
+	</UAP>
+
+	</Category>			
+	

--- a/config/asterix_cat062_1_18.xml
+++ b/config/asterix_cat062_1_18.xml
@@ -2345,7 +2345,7 @@
 					<Bits from="16" to="1" encode="signed">
 						<BitsShortName>GAL</BitsShortName>
 						<BitsName>Geometric Altitude</BitsName>
-						<BitsUnit scale="6.25" min="'1500" max="150000">ft</BitsUnit>
+						<BitsUnit scale="6.25" min="1500" max="150000">ft</BitsUnit>
 					</Bits>
 				</Fixed>
 				
@@ -2381,14 +2381,14 @@
 					<Bits from="16" to="1">
 						<BitsShortName>IAS</BitsShortName>
 						<BitsName>Indicated Air Speed</BitsName>
-						<BitsUnit scale="1" min="'0" max="1100">kt</BitsUnit>
+						<BitsUnit scale="1" min="0" max="1100">kt</BitsUnit>
 					</Bits>
 				</Fixed>				
 				<Fixed length="2">
 					<Bits from="16" to="1">
 						<BitsShortName>MNO</BitsShortName>
 						<BitsName>Mach Number</BitsName>
-						<BitsUnit scale="0.008" min="'0" max="4.096">Mach</BitsUnit>
+						<BitsUnit scale="0.008" min="0" max="4.096">Mach</BitsUnit>
 					</Bits>
 				</Fixed>
 				
@@ -2401,7 +2401,7 @@
 					<Bits from="12" to="1">
 						<BitsShortName>BPS</BitsShortName>
 						<BitsName>Barometric Pressure Setting</BitsName>
-						<BitsUnit scale="0.1" min="'0" max="409.6">mbar</BitsUnit>
+						<BitsUnit scale="0.1" min="0" max="409.6">mbar</BitsUnit>
 					</Bits>
 				</Fixed>
 

--- a/config/asterix_cat062_1_18.xml
+++ b/config/asterix_cat062_1_18.xml
@@ -18,6 +18,10 @@
     Modified:  28.04.2014. (dsalantic) Special characters removed from BitsShortName, some BitsShortName renamed, tabs aligned
     Modified:  05.05.2014. (dsalantic) Item 110 format fixed
     Modified:  04.07.2020. (fjonckers) cat062 v1.17: V & G bits added to I062/060 (correct name)
+    Modified:  04.07.2020. (fjonckers) cat062 v1.18: SFC Flag added to I062/080 5th ext.
+                                                     IDD bit added to I062/080 5th extension
+                                                     IEC bit added to I062/080 5th extension
+                                                     I062/380 STAT Field updated with values 6 and 7 to align with Cat. 020
 -->
 
 <Category id="62" name="SDPS Track Messages" ver="1.17">
@@ -336,7 +340,22 @@
 						<BitsValue val="0">Default value</BitsValue>
 						<BitsValue val="1">Duplicate Flight Plan due to manual correlation</BitsValue>
 					</Bits>
-					<Bits from="5" to="2">
+					<Bits bit="5">
+						<BitsShortName>SFC</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Surface target</BitsValue>
+					</Bits>
+					<Bits bit="4">
+						<BitsShortName>IDD</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Duplicate Flight-ID</BitsValue>
+					</Bits>
+					<Bits bit="3">
+						<BitsShortName>IEC</BitsShortName>
+						<BitsValue val="0">Default value</BitsValue>
+						<BitsValue val="1">Inconsistent Emergency Code</BitsValue>
+					</Bits>
+					<Bits bit="2">
 						<BitsShortName>spare</BitsShortName>
 						<BitsName>Spare bits set to 0</BitsName>
 						<BitsConst>0</BitsConst>
@@ -347,8 +366,6 @@
 						<BitsValue val="1">Extension into next extent</BitsValue>
 					</Bits>
 				</Fixed>
-
-
 			</Variable>
 		</DataItemFormat>
 		<DataItemNote>1. Track type and coasting can also be derived from I062/290 System Track Update Ages 2. If the system supports the technology, default value (0) means that the technology was used to produce the report 3. If the system does not support the technology, default value is meaningless.</DataItemNote>
@@ -2069,8 +2086,8 @@
 						<BitsValue val="3">Alert, no SPI, aircraft on ground</BitsValue>
 						<BitsValue val="4">Alert, SPI, aircraft airborne or on ground</BitsValue>
 						<BitsValue val="5">No alert, SPI, aircraft airborne or on ground</BitsValue>
-						<BitsValue val="6">Not assigned</BitsValue>
-						<BitsValue val="7">Not assigned</BitsValue>
+						<BitsValue val="6">Not defined</BitsValue>
+						<BitsValue val="7">Unknown or not yet extracted</BitsValue>
 					</Bits>
 					<Bits from="9" to="10">
 						<BitsShortName>spare</BitsShortName>


### PR DESCRIPTION
implemented changes from v1.16 to v1.18
V and G bits added to I062/060 
SFC Flag added to I062/080 5th ext.
IDD bit added to I062/080 5th extension
IEC bit added to I062/080 5th extension
I062/380 STAT Field updated with values 6 and 7 to align with Cat. 020
resolves #1 
compound item crashes when decoding cat062: typo in indicators var
resolves #2 